### PR TITLE
Sort rbsort playlists in place, drop --xml, release 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "baken"
-version = "3.0.4"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -167,9 +167,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb95844792e2dfdfdf9517deb10dfd36811d1540805ff81932c579de0685df4d"
+checksum = "51655736496c3678c28c3a453ee6bf5cfcae625de0e5f51b7b288e538e9865e1"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baken"
-version = "3.0.4"
+version = "3.1.0"
 edition = "2021"
 authors = ["Masanari Higashi"]
 description = "Bake'n Deck — Rekordbox → CDJ prep toolkit: loudness gain, Key+BPM playlist sort, and CDJ-safe MP3 transcode baked into your files"
@@ -36,7 +36,7 @@ walkdir = "2.4"
 chrono = "0.4"
 
 # MP3/AAC lossless gain adjustment
-mp3rgain = { version = "3.0", default-features = false, features = ["aac"] }
+mp3rgain = { version = "3.6", default-features = false, features = ["aac"] }
 
 # XML parsing (rbsort subcommand)
 quick-xml = "0.42"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rekordbox does three things in software that never survive the trip to a CDJ. Ba
 | Subcommand | The gap it fills | What it does |
 |---|---|---|
 | [`baken headroom`](#loudness-normalizer-baken-headroom) | Auto Gain is ignored on USB export | Measures LUFS / True Peak and bakes safe gain into the audio file — **no limiter**, dynamics preserved, cues stay linked |
-| [`baken rbsort`](#rekordbox-playlist-sorter-baken-rbsort) | No compound Key+BPM sort in Rekordbox | Sorts playlists by **Camelot Key (1A→12B) then BPM** and writes the order into `collection.xml` — CDJs play it in that exact order |
+| [`baken rbsort`](#rekordbox-playlist-sorter-baken-rbsort) | No compound Key+BPM sort in Rekordbox | Sorts every playlist by **Camelot Key (1A→12B) then BPM** inside your exported XML — CDJs play it in that exact order |
 | [`baken cdjsafe`](#cdj-safe-transcoder-baken-cdjsafe) | Pre-NXS2 CDJs only play MP3 reliably | Transcodes a whole playlist to **320 kbps CBR MP3** with **cues and beatgrid carried over** — the emergency-backup USB |
 
 🌐 **[baken.ravers.workers.dev](https://baken.ravers.workers.dev)** — full docs, workflow guides, and FAQ.
@@ -34,8 +34,8 @@ Pre-built binaries are available on the [Releases](https://github.com/M-Igashi/b
 
 ```bash
 baken headroom ~/Music/DJ-Tracks                # analyze & bake loudness gain (interactive)
-baken rbsort --xml collection.xml               # sort every playlist by Key+BPM
-baken cdjsafe --xml collection.xml --playlist "Sets/Friday" --out-dir ~/Music/cdjsafe
+baken rbsort collection.xml                     # sort every playlist by Key+BPM, in place
+baken cdjsafe collection.xml --playlist "Sets/Friday" --out-dir ~/Music/cdjsafe
 ```
 
 Run `baken --help` or `baken <subcommand> --help` for the full reference.
@@ -48,7 +48,7 @@ Run `baken --help` or `baken <subcommand> --help` for the full reference.
 - **Single binary** — [mp3rgain](https://github.com/M-Igashi/mp3rgain) built in; only ffmpeg required (and `rbsort` doesn't even need that)
 - **Truly lossless MP3/AAC gain** — global_gain header modification in 1.5 dB steps, no re-encode
 - **Uniform True Peak ceiling** — -0.5 dBTP by default (AES TD1008 §7B), tunable via `--tp-target`
-- **Non-destructive** — automatic backups; `rbsort`/`cdjsafe` never modify your original `collection.xml`
+- **Non-destructive** — automatic backups; `rbsort`/`cdjsafe` only ever touch an exported XML, never your Rekordbox library
 - **Metadata preserved** — files overwritten in place, so Rekordbox cues, hot cues, and beatgrids stay linked
 - **Interactive or scriptable** — guided two-stage confirmation, or flags/globs for pipelines and CI
 
@@ -315,46 +315,43 @@ At ≥256kbps, re-encoding introduces quantization noise below -90dB — far bel
 
 ## Rekordbox Playlist Sorter (`baken rbsort`)
 
-Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `baken rbsort` reads your `collection.xml`, sorts each target playlist by **Camelot Key (1A → 12B) ascending** then **BPM ascending**, and emits the sorted copies into a new `Sorted (Key+BPM)/` folder appended to the same XML. Originals are left untouched. The layout mirrors the analyzer's `backup/` directory: one container folder, each item inside keeps its source name.
+Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `baken rbsort` takes an exported Rekordbox XML and rewrites every playlist in it so its tracks run **Camelot Key (1A → 12B) ascending** then **BPM ascending**. Playlists keep their names and folder positions; only the track order inside each one changes. Rekordbox reads the sorted file back as its `rekordbox xml` tree, so you end up with a Key+BPM-sorted mirror of your `Playlists` sitting next to the originals.
 
 This is the same idea as `baken headroom` applied to playlist order: Rekordbox's software-only features (Auto Gain, multi-column sort) don't follow your tracks to the CDJ. `rbsort` bakes Key+BPM order into the playlist itself — so when you export to USB in Rekordbox's EXPORT mode, the CDJ plays the set in that exact order with no on-deck reordering.
 
 ### Workflow
 
 1. **Set key display to Alphanumeric (1A..12B notation)** in Rekordbox: *Preferences > View > Key display format > Alphanumeric*.
-2. **Export**: *File > Export Collection in xml format* → e.g. `~/Music/rekordbox/collection.xml`.
-3. **Run rbsort**:
+2. **Export**: *File > Export Collection in xml format*. Always save to the same path, e.g. `~/Music/rekordbox/collection.xml`.
+3. **Run rbsort** on that file. It is sorted in place:
    ```bash
-   # Sort every TrackID-referenced playlist in the XML
-   baken rbsort --xml ~/Music/rekordbox/collection.xml
+   baken rbsort ~/Music/rekordbox/collection.xml
 
-   # Or target one playlist (top-level: just the name)
-   baken rbsort \
-     --xml ~/Music/rekordbox/collection.xml \
-     --playlist "Happy House and Trance"
+   # Only one playlist (top-level: just the name; nested: "Folder/Playlist")
+   baken rbsort ~/Music/rekordbox/collection.xml --playlist "Sets/Friday"
 
-   # Or target one nested under a folder
-   baken rbsort \
-     --xml ~/Music/rekordbox/collection.xml \
-     --playlist "Sets/Friday"
+   # Keep the export untouched and write elsewhere
+   baken rbsort ~/Music/rekordbox/collection.xml -o ~/Music/rekordbox/sorted.xml
    ```
-   Output defaults to `collection-out.xml` next to the input. Pass `--output <PATH>` to override.
-4. **Point Rekordbox at the output XML**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select `collection-out.xml`, then **restart Rekordbox** (Rekordbox only re-reads the XML on startup).
-5. **Open the `rekordbox xml` tree** in the left sidebar. It is a *separate* tree from your main library — switch to it from the **sidebar icon column** on the far left (the icon labeled `rekordbox xml`). Inside you'll find a new folder `Sorted (Key+BPM)/` containing each sorted playlist under its original name.
-6. **Verify the sort** by clicking any playlist inside `Sorted (Key+BPM)/` — tracks should run `1A` (lowest BPM) → `1B` → `2A` → … → `12B` (highest BPM).
-7. **Drag** the playlists you want from `Sorted (Key+BPM)/` into your main `Playlists` collection. Your original playlists (still in `Playlists`) are unchanged.
-8. **Export to USB for CDJ**: switch Rekordbox to *EXPORT* mode (top-left dropdown), plug in your USB / SD, then **right-click the playlist → Export Playlist**. CDJs read tracks in playlist order by default — your Key+BPM sort plays back on the deck in that exact order.
+4. **One-time setup**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select that same file.
+5. **Restart Rekordbox** (it only re-reads the XML on startup) and open the **`rekordbox xml` tree** in the left sidebar. It is a *separate* tree from your main library — switch to it from the sidebar icon column on the far left. It mirrors your `Playlists` folder structure, every playlist already in Key+BPM order: `1A` (lowest BPM) → `1B` → `2A` → … → `12B` (highest BPM).
+6. **Use it**: drag any playlist from the `rekordbox xml` tree into your main `Playlists` (it lands as a new playlist; your original is unchanged), switch to *EXPORT* mode, plug in your USB / SD, then **right-click the playlist → Export Playlist**. CDJs read tracks in playlist order by default — your Key+BPM sort plays back on the deck in that exact order.
 
-> The sorted results live **only** inside the `rekordbox xml > Sorted (Key+BPM)/` folder, not in your main `Playlists`. If you only see the originals, you're looking at the local library — switch sidebar trees.
+**Keeping it in sync**: whenever your playlists change, repeat steps 2, 3 and the restart. The file path never changes, so the Imported Library setting keeps pointing at the freshly sorted export and the `rekordbox xml` tree stays an always-sorted copy of your library.
 
-### Flags
+> The sorted playlists live **only** in the `rekordbox xml` tree, not in your main `Playlists`. If you only see unsorted originals, you're looking at the local library — switch sidebar trees.
 
-| Flag | Description |
+### Usage
+
+```
+baken rbsort <XML> [--playlist <PATH>] [-o <PATH>]
+```
+
+| Argument / Flag | Description |
 |------|-------------|
-| `--xml <PATH>` | Path to `collection.xml` (required) |
-| `--playlist <PATH>` | Source playlist under the Rekordbox `Playlists` root. **Optional** — if omitted, every TrackID-referenced playlist in the XML is sorted. Top-level playlists: just the name (e.g. `"Happy House and Trance"`). Nested: `/`-separate folder/playlist names (e.g. `"Folder/SubFolder/MyPlaylist"`) |
-| `--output <PATH>` (`-o`) | Output XML path. Optional — defaults to `<input-stem>-out.<ext>` next to the input |
-| `--name <NAME>` | Override the sorted playlist's name. Only valid with `--playlist`. When sorting all playlists, each sorted copy reuses its source name |
+| `<XML>` | Exported Rekordbox XML (required). Sorted in place unless `--output` is given |
+| `--playlist <PATH>` | Sort only this playlist. Top-level playlists: just the name (e.g. `"Happy House and Trance"`). Nested: `/`-separate folder/playlist names (e.g. `"Folder/SubFolder/MyPlaylist"`). Omitted: every TrackID-referenced playlist is sorted |
+| `--output <PATH>` (`-o`) | Write the result here instead of overwriting the input XML |
 
 ### Sort Rules
 
@@ -367,9 +364,9 @@ See [docs/rbsort-sort-comparison.md](docs/rbsort-sort-comparison.md) for a 6-tra
 ### Notes
 
 - Requires the `Tonality` field to be exported as 1A..12B (Rekordbox's "Alphanumeric" key display format). Non-matching values (e.g. `Am`, `C#`) are silently sorted last.
-- Only `KeyType="0"` (TrackID-referenced) playlists are supported. In all-playlists mode, non-`KeyType=0` playlists are silently skipped; for a single target, `rbsort` errors out.
+- Only `KeyType="0"` (TrackID-referenced) playlists are sorted. In all-playlists mode, other playlists pass through unchanged; for a single target, `rbsort` errors out.
+- Only the order of `<TRACK Key="…"/>` references changes. Playlist names, folder structure, `Count`/`Entries` attributes, whitespace and everything else in the XML are preserved byte-for-byte, so running `rbsort` twice on the same file is a no-op.
 - `baken rbsort` does **not** require ffmpeg — only the `headroom` and `cdjsafe` subcommands do.
-- A single `Sorted (Key+BPM)/` folder is appended inside the `<PLAYLISTS>` ROOT NODE, regardless of how many playlists were processed. The ROOT `Count` is bumped by 1.
 
 ## CDJ-safe Transcoder (`baken cdjsafe`)
 
@@ -378,8 +375,7 @@ See [docs/rbsort-sort-comparison.md](docs/rbsort-sort-comparison.md) for a 6-tra
 Pre-NXS2 CDJs (CDJ-2000NXS, CDJ-2000, CDJ-900NXS, CDJ-850, …) have inconsistent or absent support for anything that isn't MP3: FLAC needs an NXS2 (2016+), and ALAC/AIFF/WAV/AAC fail on specific firmware combinations — sometimes mid-set. `baken cdjsafe` is the emergency-backup path: it takes a gig playlist and produces a USB-ready set of files that **will play on any CDJ**, with your cues and beatgrid intact.
 
 ```bash
-baken cdjsafe \
-  --xml ~/Music/rekordbox/collection.xml \
+baken cdjsafe ~/Music/rekordbox/collection.xml \
   --playlist "Sets/Friday" \
   --out-dir ~/Music/cdjsafe-friday
 ```
@@ -408,11 +404,15 @@ If any track fails to convert, **no XML is written** — a partial USB defeats t
 3. Right-click the imported tracks → **Import to Collection**. Cues and beatgrid come with them — no re-analysis needed.
 4. Export the playlist to USB in EXPORT mode as usual.
 
-### Flags
+### Usage
 
-| Flag | Description |
+```
+baken cdjsafe <XML> --playlist <PATH> --out-dir <DIR> [-o <PATH>]
+```
+
+| Argument / Flag | Description |
 |------|-------------|
-| `--xml <PATH>` | Path to `collection.xml` (required) |
+| `<XML>` | Exported Rekordbox XML (required) |
 | `--playlist <PATH>` | Playlist to convert (required). Top-level: just the name; nested: `Folder/Playlist` |
 | `--out-dir <DIR>` | Directory for the MP3 files (required; created if missing) |
 | `--output <PATH>` (`-o`) | Output XML path. Defaults to `<input-stem>-out.<ext>` next to the input |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,23 @@
-# Bake'n Deck 3.0.4 - artwork preservation
+# Bake'n Deck 3.1.0 - rbsort in-place sorting and a simpler CLI
 
 ## Highlights
 
-- **Embedded cover art keeps its original format.** `baken headroom` passed no video codec to ffmpeg when applying gain, so the muxer default took over and re-encoded the attached picture. FLAC, MP3, and AIFF outputs got PNG, turning a JPEG cover into a much larger PNG (a 500x500 photo-like cover took a FLAC from 205 KB to 404 KB in a single pass). M4A was worse: the ipod muxer defaults to h264 and rejects it, so the AAC re-encode path failed outright on any file with artwork. Both ffmpeg gain paths now stream-copy the picture, so the original bytes survive untouched. Fixes #77.
+- **`rbsort` now sorts playlists in place, with no wrapper folder.** Previously every sorted playlist was written into a new `Sorted (Key+BPM)/` folder, so the output XML held both an unsorted original and a sorted copy of each playlist. That copy was redundant: the file you feed `rbsort` is a throwaway export, and Rekordbox loads the result as the separate `rekordbox xml` tree, so your real library is never at risk. Each playlist is now re-sorted inside its own node instead. Names, folder structure, `Count` and `Entries` attributes, and even whitespace are preserved byte-for-byte, so the `rekordbox xml` tree becomes a Key+BPM-sorted mirror of your `Playlists`, and running `rbsort` twice on the same file is a no-op.
+- **The XML path is now a positional argument for both `rbsort` and `cdjsafe`.** `--xml` carried no information when the XML is the one thing every invocation must name, so `baken rbsort --xml collection.xml` is now `baken rbsort collection.xml`, and `baken cdjsafe --xml collection.xml --playlist … --out-dir …` is now `baken cdjsafe collection.xml --playlist … --out-dir …`. `rbsort` also defaults to sorting the input file in place, with `-o` available when you want the export left untouched. Its `--name` flag is gone, since in-place sorting never creates a playlist to name.
+- **A repeatable sync loop.** Export your collection to a fixed path, run `rbsort` on it, and point *Preferences > Advanced > Database > rekordbox xml > Imported Library* at that same file once. From then on, re-exporting to the same path, re-running `rbsort`, and restarting Rekordbox keeps the `rekordbox xml` tree in sync with your library, always sorted.
 
-**Full Changelog**: https://github.com/M-Igashi/baken/compare/v3.0.3...v3.0.4
+## Breaking Changes
+
+- `baken rbsort --xml <PATH>` → `baken rbsort <PATH>`
+- `baken cdjsafe --xml <PATH>` → `baken cdjsafe <PATH>`
+- `baken rbsort` writes to its input file by default instead of `<stem>-out.xml`. Pass `-o <PATH>` for the old behavior. `cdjsafe` still defaults to `<stem>-out.xml`.
+- `baken rbsort --name <NAME>` has been removed.
+- The `Sorted (Key+BPM)/` folder is no longer produced. Sorted playlists appear in the `rekordbox xml` tree under their original names and folders.
+
+## Other Changes
+
+- **Fixed the build against quick-xml 0.42** (#80), which moved element and attribute names from bytes to `&str`. The dependency bump had landed without a compile check, since no CI job builds on pushes to `main`.
+- Refreshed the lockfile off a yanked `chacha20` 0.10.1 (a transitive dependency) onto 0.10.2.
+- Updated the built-in mp3rgain library from 3.4.0 to 3.6.0. Gain application is unchanged; verified that MP3, AAC/M4A, and FLAC gain still land on target with the MP3 file staying byte-identical in size.
+
+**Full Changelog**: https://github.com/M-Igashi/baken/compare/v3.0.4...v3.1.0

--- a/src/args.rs
+++ b/src/args.rs
@@ -26,7 +26,12 @@ pub enum Command {
     /// folder as an argument). Provide paths or any flag to run in
     /// non-interactive (scriptable) mode.
     Headroom(HeadroomArgs),
-    /// Sort a Rekordbox playlist by Camelot Key then BPM, output as a new XML playlist.
+    /// Sort Rekordbox playlists by Camelot Key then BPM, in place in the exported XML.
+    ///
+    /// Every playlist keeps its name and folder position; only the track order
+    /// inside each one changes. Point Rekordbox's "rekordbox xml" Imported
+    /// Library at the file once, then re-export and re-run whenever your
+    /// playlists change.
     Rbsort(RbsortArgs),
     /// Transcode a Rekordbox playlist to CDJ-safe MP3s (320 kbps CBR, 44.1 kHz)
     /// with cues and beatgrid carried over via a new XML playlist.
@@ -46,7 +51,12 @@ pub struct HeadroomArgs {
     pub paths: Vec<String>,
 
     /// Delivery True Peak ceiling in dBTP (default: -0.5). Negative values only.
-    #[arg(long, value_name = "DB", allow_hyphen_values = true, conflicts_with = "tp_split_bitrate")]
+    #[arg(
+        long,
+        value_name = "DB",
+        allow_hyphen_values = true,
+        conflicts_with = "tp_split_bitrate"
+    )]
     pub tp_target: Option<f64>,
 
     /// Restore the legacy bitrate-dependent ceiling (-0.5 dBTP for ≥256 kbps,
@@ -141,8 +151,8 @@ impl HeadroomArgs {
 
 #[derive(Args, Debug)]
 pub struct CdjsafeArgs {
-    /// Path to rekordbox collection.xml (File > Export Collection in xml format)
-    #[arg(long, value_name = "PATH")]
+    /// Exported rekordbox XML (File > Export Collection in xml format)
+    #[arg(value_name = "XML")]
     pub xml: PathBuf,
 
     /// Playlist to convert. Top-level playlists: just the name; nested:
@@ -162,25 +172,19 @@ pub struct CdjsafeArgs {
 
 #[derive(Args, Debug)]
 pub struct RbsortArgs {
-    /// Path to rekordbox collection.xml (File > Export Collection in xml format)
-    #[arg(long, value_name = "PATH")]
+    /// Exported rekordbox XML (File > Export Collection in xml format).
+    /// Sorted in place unless --output is given.
+    #[arg(value_name = "XML")]
     pub xml: PathBuf,
 
-    /// Source playlist under the Rekordbox `Playlists` root. Optional — if
-    /// omitted, every TrackID-referenced playlist in the XML is sorted. For a
-    /// single target, use the playlist name as-is for top-level playlists
-    /// (e.g. "MyPlaylist"), or '/'-separate folder/playlist names for nested
-    /// ones (e.g. "Folder/SubFolder/MyPlaylist").
+    /// Sort only this playlist. Top-level playlists: just the name
+    /// (e.g. "MyPlaylist"); nested: '/'-separate folder/playlist names
+    /// (e.g. "Folder/SubFolder/MyPlaylist"). Omitted: every TrackID-referenced
+    /// playlist in the XML is sorted.
     #[arg(long, value_name = "PATH")]
     pub playlist: Option<String>,
 
-    /// Output XML path. Optional — defaults to the input filename with "-out"
-    /// appended to the stem, in the same directory (e.g. collection.xml -> collection-out.xml).
+    /// Write the result here instead of overwriting the input XML.
     #[arg(long, short, value_name = "PATH")]
     pub output: Option<PathBuf>,
-
-    /// Override the new playlist's name. Only valid together with `--playlist`.
-    /// When sorting all playlists, each sorted copy reuses its source name.
-    #[arg(long, value_name = "NAME")]
-    pub name: Option<String>,
 }

--- a/src/cdjsafe/mod.rs
+++ b/src/cdjsafe/mod.rs
@@ -2,17 +2,18 @@ mod location;
 mod transcode;
 mod xml;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use console::style;
 use rayon::prelude::*;
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::analyzer;
 use crate::args::CdjsafeArgs;
 use crate::cli::make_progress_bar;
-use crate::rbsort::{default_output_path, split_playlist_path};
+use crate::rbsort::split_playlist_path;
 
 use location::{encode_location, sanitize_filename};
 use transcode::SourceInfo;
@@ -36,8 +37,8 @@ pub fn run(args: &CdjsafeArgs) -> Result<()> {
         bail!("--playlist must not be empty");
     }
 
-    let xml_data = fs::read(&args.xml)
-        .with_context(|| format!("Failed to read {}", args.xml.display()))?;
+    let xml_data =
+        fs::read(&args.xml).with_context(|| format!("Failed to read {}", args.xml.display()))?;
 
     let (track_ids, max_track_id) = xml::find_playlist(&xml_data, &target)?;
     if track_ids.is_empty() {
@@ -190,12 +191,7 @@ fn build_new_tracks(
         .collect()
 }
 
-fn print_report(
-    sources: &[SourceTrack],
-    actions: &[Action],
-    playlist_name: &str,
-    output: &Path,
-) {
+fn print_report(sources: &[SourceTrack], actions: &[Action], playlist_name: &str, output: &Path) {
     let count = |a: Action| actions.iter().filter(|&&x| x == a).count();
     let (copied, lossless, lossy) = (
         count(Action::Copy),
@@ -251,9 +247,42 @@ fn print_report(
     );
 }
 
+/// Derive default output path: same directory as input, filename stem with
+/// "-out" appended, extension preserved. e.g. `/a/b/c.xml` -> `/a/b/c-out.xml`.
+fn default_output_path(input: &Path) -> Result<PathBuf> {
+    let stem = input
+        .file_stem()
+        .ok_or_else(|| anyhow!("XML path has no filename: {}", input.display()))?;
+    let mut name = OsString::from(stem);
+    name.push("-out");
+    if let Some(ext) = input.extension() {
+        name.push(".");
+        name.push(ext);
+    }
+    Ok(input.with_file_name(name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_output_appends_out_to_stem() {
+        let p = default_output_path(Path::new("/a/b/c.xml")).unwrap();
+        assert_eq!(p, PathBuf::from("/a/b/c-out.xml"));
+    }
+
+    #[test]
+    fn default_output_for_bare_filename() {
+        let p = default_output_path(Path::new("coll.xml")).unwrap();
+        assert_eq!(p, PathBuf::from("coll-out.xml"));
+    }
+
+    #[test]
+    fn default_output_without_extension() {
+        let p = default_output_path(Path::new("/a/b/c")).unwrap();
+        assert_eq!(p, PathBuf::from("/a/b/c-out"));
+    }
 
     fn src(location: &str) -> SourceTrack {
         SourceTrack::test_stub(location)

--- a/src/cdjsafe/xml.rs
+++ b/src/cdjsafe/xml.rs
@@ -16,7 +16,7 @@ pub const CDJSAFE_FOLDER_NAME: &str = "CDJ-safe (MP3)";
 /// Marker appended to the `Comments` attribute of every emitted track so the
 /// MP3 duplicates are distinguishable from the originals after
 /// "Import to Collection".
-const COMMENT_MARKER: &[u8] = b"[cdjsafe]";
+const COMMENT_MARKER: &str = "[cdjsafe]";
 
 /// A source `<TRACK>` captured verbatim from `<COLLECTION>`: raw (still
 /// escaped) attributes plus all child events (`<TEMPO>`, `<POSITION_MARK>`)
@@ -26,7 +26,7 @@ pub struct SourceTrack {
     pub name: String,
     pub location: String,
     pub has_total_time: bool,
-    attrs: Vec<(Vec<u8>, Vec<u8>)>,
+    attrs: Vec<(String, String)>,
     children: Vec<Event<'static>>,
 }
 
@@ -53,14 +53,14 @@ impl SourceTrack {
 }
 
 /// Attributes recomputed for the new MP3 rather than inherited.
-const RECOMPUTED: &[&[u8]] = &[
-    b"TrackID",
-    b"Location",
-    b"Kind",
-    b"Size",
-    b"BitRate",
-    b"SampleRate",
-    b"Comments",
+const RECOMPUTED: &[&str] = &[
+    "TrackID",
+    "Location",
+    "Kind",
+    "Size",
+    "BitRate",
+    "SampleRate",
+    "Comments",
 ];
 
 /// Pass 1: find the target playlist (path under ROOT), return its TrackID
@@ -80,14 +80,14 @@ pub fn find_playlist(xml_data: &[u8], target: &[String]) -> Result<(Vec<String>,
         match reader.read_event() {
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => match e.name().as_ref() {
-                b"COLLECTION" => in_collection = true,
-                b"PLAYLISTS" => in_playlists = true,
-                b"TRACK" if in_collection => {
-                    if let Some(id) = get_attr(&e, b"TrackID")? {
+                "COLLECTION" => in_collection = true,
+                "PLAYLISTS" => in_playlists = true,
+                "TRACK" if in_collection => {
+                    if let Some(id) = get_attr(&e, "TrackID")? {
                         max_id = max_id.max(id.parse().unwrap_or(0));
                     }
                 }
-                b"NODE" if in_playlists => {
+                "NODE" if in_playlists => {
                     let (name, ty, key_type) = playlist_node_attrs(&e)?;
                     path_stack.push(name);
                     if ty == "1" && path_stack.len() > 1 && path_stack[1..] == target[..] {
@@ -105,23 +105,23 @@ pub fn find_playlist(xml_data: &[u8], target: &[String]) -> Result<(Vec<String>,
                 _ => {}
             },
             Ok(Event::Empty(e)) => match e.name().as_ref() {
-                b"TRACK" if in_collection => {
-                    if let Some(id) = get_attr(&e, b"TrackID")? {
+                "TRACK" if in_collection => {
+                    if let Some(id) = get_attr(&e, "TrackID")? {
                         max_id = max_id.max(id.parse().unwrap_or(0));
                     }
                 }
-                b"TRACK" if capture.is_some() => {
-                    if let Some(k) = get_attr(&e, b"Key")? {
+                "TRACK" if capture.is_some() => {
+                    if let Some(k) = get_attr(&e, "Key")? {
                         capture.as_mut().unwrap().push(k);
                     }
                 }
-                b"NODE" if in_playlists => {} // self-closing NODE: nothing to match
+                "NODE" if in_playlists => {} // self-closing NODE: nothing to match
                 _ => {}
             },
             Ok(Event::End(e)) => match e.name().as_ref() {
-                b"COLLECTION" => in_collection = false,
-                b"PLAYLISTS" => in_playlists = false,
-                b"NODE" if in_playlists => {
+                "COLLECTION" => in_collection = false,
+                "PLAYLISTS" => in_playlists = false,
+                "NODE" if in_playlists => {
                     if capture.is_some() && path_stack.len() > 1 && path_stack[1..] == target[..] {
                         found = capture.take();
                     }
@@ -129,7 +129,11 @@ pub fn find_playlist(xml_data: &[u8], target: &[String]) -> Result<(Vec<String>,
                 }
                 _ => {}
             },
-            Err(e) => bail!("XML parse error at byte {}: {}", reader.buffer_position(), e),
+            Err(e) => bail!(
+                "XML parse error at byte {}: {}",
+                reader.buffer_position(),
+                e
+            ),
             _ => {}
         }
     }
@@ -153,10 +157,10 @@ pub fn collect_tracks(xml_data: &[u8], track_ids: &[String]) -> Result<Vec<Sourc
     loop {
         match reader.read_event() {
             Ok(Event::Eof) => break,
-            Ok(Event::Start(e)) if e.name().as_ref() == b"COLLECTION" => in_collection = true,
-            Ok(Event::End(e)) if e.name().as_ref() == b"COLLECTION" => in_collection = false,
-            Ok(Event::Start(e)) if in_collection && e.name().as_ref() == b"TRACK" => {
-                let id = get_attr(&e, b"TrackID")?.unwrap_or_default();
+            Ok(Event::Start(e)) if e.name().as_ref() == "COLLECTION" => in_collection = true,
+            Ok(Event::End(e)) if e.name().as_ref() == "COLLECTION" => in_collection = false,
+            Ok(Event::Start(e)) if in_collection && e.name().as_ref() == "TRACK" => {
+                let id = get_attr(&e, "TrackID")?.unwrap_or_default();
                 if wanted.contains(id.as_str()) {
                     let mut track = source_track_from(&e, id.clone())?;
                     // Consume children verbatim until the matching </TRACK>.
@@ -168,7 +172,7 @@ pub fn collect_tracks(xml_data: &[u8], track_ids: &[String]) -> Result<Vec<Sourc
                                 track.children.push(Event::Start(c).into_owned());
                             }
                             Ok(Event::End(c)) => {
-                                if depth == 0 && c.name().as_ref() == b"TRACK" {
+                                if depth == 0 && c.name().as_ref() == "TRACK" {
                                     break;
                                 }
                                 depth -= 1;
@@ -185,14 +189,18 @@ pub fn collect_tracks(xml_data: &[u8], track_ids: &[String]) -> Result<Vec<Sourc
                     reader.read_to_end(e.name())?;
                 }
             }
-            Ok(Event::Empty(e)) if in_collection && e.name().as_ref() == b"TRACK" => {
-                let id = get_attr(&e, b"TrackID")?.unwrap_or_default();
+            Ok(Event::Empty(e)) if in_collection && e.name().as_ref() == "TRACK" => {
+                let id = get_attr(&e, "TrackID")?.unwrap_or_default();
                 if wanted.contains(id.as_str()) {
                     let track = source_track_from(&e, id.clone())?;
                     by_id.insert(id, track);
                 }
             }
-            Err(e) => bail!("XML parse error at byte {}: {}", reader.buffer_position(), e),
+            Err(e) => bail!(
+                "XML parse error at byte {}: {}",
+                reader.buffer_position(),
+                e
+            ),
             _ => {}
         }
     }
@@ -201,7 +209,10 @@ pub fn collect_tracks(xml_data: &[u8], track_ids: &[String]) -> Result<Vec<Sourc
     for id in track_ids {
         match by_id.remove(id) {
             Some(t) => out.push(t),
-            None => bail!("Playlist references TrackID {} not present in <COLLECTION>", id),
+            None => bail!(
+                "Playlist references TrackID {} not present in <COLLECTION>",
+                id
+            ),
         }
     }
     Ok(out)
@@ -215,22 +226,22 @@ fn source_track_from(e: &BytesStart, id: String) -> Result<SourceTrack> {
     for attr in e.attributes() {
         let attr = attr?;
         match attr.key.as_ref() {
-            b"Name" => {
+            "Name" => {
                 #[allow(deprecated)]
                 {
                     name = attr.unescape_value()?.into_owned();
                 }
             }
-            b"Location" => {
+            "Location" => {
                 #[allow(deprecated)]
                 {
                     location_raw = attr.unescape_value()?.into_owned();
                 }
             }
-            b"TotalTime" => has_total_time = true,
+            "TotalTime" => has_total_time = true,
             _ => {}
         }
-        attrs.push((attr.key.as_ref().to_vec(), attr.value.into_owned()));
+        attrs.push((attr.key.as_ref().to_string(), attr.value.into_owned()));
     }
     let location = decode_location(&location_raw)
         .with_context(|| format!("Track '{}' (TrackID {})", name, id))?;
@@ -268,23 +279,23 @@ pub fn rewrite_xml(
             match reader.read_event() {
                 Ok(Event::Eof) => break,
                 Ok(Event::Start(e)) => match e.name().as_ref() {
-                    b"COLLECTION" => {
+                    "COLLECTION" => {
                         writer.write_event(Event::Start(bump_count_attr(
                             &e,
-                            b"Entries",
+                            "Entries",
                             new_tracks.len(),
                         )?))?;
                     }
-                    b"PLAYLISTS" => {
+                    "PLAYLISTS" => {
                         in_playlists = true;
                         playlists_depth = 0;
                         writer.write_event(Event::Start(e))?;
                     }
-                    b"NODE" if in_playlists => {
+                    "NODE" if in_playlists => {
                         playlists_depth += 1;
                         if playlists_depth == 1 {
                             // ROOT NODE — bump Count by 1 (we insert one folder).
-                            writer.write_event(Event::Start(bump_count_attr(&e, b"Count", 1)?))?;
+                            writer.write_event(Event::Start(bump_count_attr(&e, "Count", 1)?))?;
                         } else {
                             writer.write_event(Event::Start(e))?;
                         }
@@ -292,20 +303,20 @@ pub fn rewrite_xml(
                     _ => writer.write_event(Event::Start(e))?,
                 },
                 Ok(Event::End(e)) => match e.name().as_ref() {
-                    b"COLLECTION" => {
+                    "COLLECTION" => {
                         for (src, new) in sources.iter().zip(new_tracks) {
                             emit_track(&mut writer, src, new)?;
                         }
                         writer.write_event(Event::End(e))?;
                     }
-                    b"NODE" if in_playlists => {
+                    "NODE" if in_playlists => {
                         if playlists_depth == 1 {
                             emit_playlist_folder(&mut writer, playlist_name, new_tracks)?;
                         }
                         playlists_depth -= 1;
                         writer.write_event(Event::End(e))?;
                     }
-                    b"PLAYLISTS" => {
+                    "PLAYLISTS" => {
                         in_playlists = false;
                         writer.write_event(Event::End(e))?;
                     }
@@ -330,40 +341,38 @@ fn emit_track<W: std::io::Write>(
     let mut e = BytesStart::new("TRACK");
     let mut comments_done = false;
     for (key, raw_value) in &src.attrs {
-        match key.as_slice() {
-            b"TrackID" => e.push_attribute(("TrackID", track_id.as_str())),
-            b"Location" => e.push_attribute(("Location", new.location_url.as_str())),
-            b"Kind" => e.push_attribute(("Kind", "MP3 File")),
-            b"Size" => e.push_attribute(("Size", size.as_str())),
-            b"BitRate" => e.push_attribute(("BitRate", "320")),
-            b"SampleRate" => e.push_attribute(("SampleRate", "44100")),
-            b"Comments" => {
+        match key.as_str() {
+            "TrackID" => e.push_attribute(("TrackID", track_id.as_str())),
+            "Location" => e.push_attribute(("Location", new.location_url.as_str())),
+            "Kind" => e.push_attribute(("Kind", "MP3 File")),
+            "Size" => e.push_attribute(("Size", size.as_str())),
+            "BitRate" => e.push_attribute(("BitRate", "320")),
+            "SampleRate" => e.push_attribute(("SampleRate", "44100")),
+            "Comments" => {
                 // Append the marker to the raw (already escaped) source value.
                 let mut v = raw_value.clone();
                 if !v.is_empty() {
-                    v.push(b' ');
+                    v.push(' ');
                 }
-                v.extend_from_slice(COMMENT_MARKER);
-                push_raw_attr(&mut e, b"Comments", &v);
+                v.push_str(COMMENT_MARKER);
+                push_raw_attr(&mut e, "Comments", &v);
                 comments_done = true;
             }
             _ => push_raw_attr(&mut e, key, raw_value),
         }
     }
     // Add any recomputed attribute the source lacked.
-    let present: HashSet<&[u8]> = src.attrs.iter().map(|(k, _)| k.as_slice()).collect();
+    let present: HashSet<&str> = src.attrs.iter().map(|(k, _)| k.as_str()).collect();
     for missing in RECOMPUTED {
         if present.contains(missing) {
             continue;
         }
         match *missing {
-            b"Kind" => e.push_attribute(("Kind", "MP3 File")),
-            b"Size" => e.push_attribute(("Size", size.as_str())),
-            b"BitRate" => e.push_attribute(("BitRate", "320")),
-            b"SampleRate" => e.push_attribute(("SampleRate", "44100")),
-            b"Comments" if !comments_done => {
-                push_raw_attr(&mut e, b"Comments", COMMENT_MARKER)
-            }
+            "Kind" => e.push_attribute(("Kind", "MP3 File")),
+            "Size" => e.push_attribute(("Size", size.as_str())),
+            "BitRate" => e.push_attribute(("BitRate", "320")),
+            "SampleRate" => e.push_attribute(("SampleRate", "44100")),
+            "Comments" if !comments_done => push_raw_attr(&mut e, "Comments", COMMENT_MARKER),
             _ => {}
         }
     }
@@ -382,7 +391,7 @@ fn emit_track<W: std::io::Write>(
 
 /// Push an attribute whose value bytes are already XML-escaped (taken
 /// verbatim from the source document) without re-escaping.
-fn push_raw_attr(e: &mut BytesStart, key: &[u8], value: &[u8]) {
+fn push_raw_attr(e: &mut BytesStart, key: &str, value: &str) {
     e.push_attribute(Attribute {
         key: QName(key),
         value: Cow::Borrowed(value),
@@ -497,7 +506,9 @@ mod tests {
         assert!(out_str.contains(r#"BitRate="320""#));
         assert!(out_str.contains(r#"SampleRate="44100""#));
         assert!(out_str.contains(r#"Comments="great tune [cdjsafe]""#));
-        assert!(out_str.contains(r#"Location="file://localhost/Users/dj/cdjsafe/alpha%20beta.mp3""#));
+        assert!(
+            out_str.contains(r#"Location="file://localhost/Users/dj/cdjsafe/alpha%20beta.mp3""#)
+        );
         // Cue/grid children duplicated into the new track (source had one set)
         assert_eq!(out_str.matches(r#"Start="30.5""#).count(), 2);
         assert_eq!(out_str.matches("<TEMPO ").count(), 2);

--- a/src/rbsort/mod.rs
+++ b/src/rbsort/mod.rs
@@ -1,10 +1,8 @@
 mod camelot;
 mod xml;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use console::style;
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
 
 use crate::args::RbsortArgs;
 
@@ -20,46 +18,33 @@ pub fn run(args: &RbsortArgs) -> Result<()> {
         None => None,
     };
 
-    if target_path.is_none() && args.name.is_some() {
-        bail!("--name is only valid with --playlist; in all-playlists mode each sorted copy reuses its source name");
-    }
-
-    let output = match &args.output {
-        Some(p) => p.clone(),
-        None => default_output_path(&args.xml)?,
-    };
-
-    let target_slice = target_path.as_deref();
-    let sorted = xml::sort_and_write(&args.xml, &output, target_slice, args.name.as_deref())?;
-
+    let output = args.output.as_ref().unwrap_or(&args.xml);
+    let sorted = xml::sort_and_write(&args.xml, output, target_path.as_deref())?;
     let total_tracks: usize = sorted.iter().map(|p| p.track_ids.len()).sum();
 
-    if target_slice.is_some() {
-        let only = &sorted[0];
+    if let [only] = sorted.as_slice() {
         println!(
-            "{} Sorted {} tracks into '{}/{}' → {}",
+            "{} Sorted {} tracks in '{}' by Key+BPM → {}",
             style("✓").green().bold(),
             style(only.track_ids.len()).cyan(),
-            style(xml::SORTED_FOLDER_NAME).bold(),
-            style(&only.name).bold(),
+            style(only.path.join("/")).bold(),
             output.display()
         );
     } else {
         println!(
-            "{} Sorted {} playlists ({} total tracks) into '{}/' → {}",
+            "{} Sorted {} playlists ({} tracks) by Key+BPM → {}",
             style("✓").green().bold(),
             style(sorted.len()).cyan(),
             style(total_tracks).cyan(),
-            style(xml::SORTED_FOLDER_NAME).bold(),
             output.display()
         );
     }
     println!(
-        "  {} Import via Rekordbox: Preferences > Advanced > Database > rekordbox xml",
+        "  {} Rekordbox: Preferences > Advanced > Database > rekordbox xml > Imported Library → this file (one-time setup)",
         style("ℹ").blue()
     );
     println!(
-        "  {} Restart Rekordbox, then open the 'rekordbox xml' tree in the left sidebar",
+        "  {} Restart Rekordbox; the sorted playlists appear under the 'rekordbox xml' tree in the left sidebar",
         style("ℹ").blue()
     );
     Ok(())
@@ -70,48 +55,4 @@ pub(crate) fn split_playlist_path(s: &str) -> Vec<String> {
         .map(|p| p.trim().to_string())
         .filter(|p| !p.is_empty())
         .collect()
-}
-
-/// Derive default output path: same directory as input, filename stem with
-/// "-out" appended, extension preserved. e.g. `/a/b/c.xml` -> `/a/b/c-out.xml`.
-pub(crate) fn default_output_path(input: &Path) -> Result<PathBuf> {
-    let stem = input
-        .file_stem()
-        .ok_or_else(|| anyhow!("--xml has no filename: {}", input.display()))?;
-    let mut name = OsString::from(stem);
-    name.push("-out");
-    if let Some(ext) = input.extension() {
-        name.push(".");
-        name.push(ext);
-    }
-    Ok(input.with_file_name(name))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_output_appends_out_to_stem() {
-        let p = default_output_path(Path::new("/a/b/c.xml")).unwrap();
-        assert_eq!(p, PathBuf::from("/a/b/c-out.xml"));
-    }
-
-    #[test]
-    fn default_output_preserves_relative_dir() {
-        let p = default_output_path(Path::new("rel/dir/coll.xml")).unwrap();
-        assert_eq!(p, PathBuf::from("rel/dir/coll-out.xml"));
-    }
-
-    #[test]
-    fn default_output_for_bare_filename() {
-        let p = default_output_path(Path::new("coll.xml")).unwrap();
-        assert_eq!(p, PathBuf::from("coll-out.xml"));
-    }
-
-    #[test]
-    fn default_output_without_extension() {
-        let p = default_output_path(Path::new("/a/b/c")).unwrap();
-        assert_eq!(p, PathBuf::from("/a/b/c-out"));
-    }
 }

--- a/src/rbsort/xml.rs
+++ b/src/rbsort/xml.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
 use std::cmp::Ordering;
@@ -7,10 +7,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::camelot::parse_camelot;
-use crate::xmlutil::{bump_count_attr, emit_playlist, get_attr, playlist_node_attrs};
-
-/// Name of the Type=0 folder NODE that holds all sorted playlists.
-pub const SORTED_FOLDER_NAME: &str = "Sorted (Key+BPM)";
+use crate::xmlutil::{get_attr, playlist_node_attrs};
 
 #[derive(Debug, Clone, Default)]
 struct TrackMeta {
@@ -18,11 +15,10 @@ struct TrackMeta {
     bpm: Option<f64>,
 }
 
-/// One playlist worth of sorted track refs, ready to be written into the
-/// `Sorted (Key+BPM)` folder under the same name as its source.
+/// One playlist's sorted track refs, written back into its own `<NODE>`.
 #[derive(Debug, Clone)]
 pub struct SortedPlaylist {
-    pub name: String,
+    pub path: Vec<String>, // path under ROOT (excluding ROOT)
     pub track_ids: Vec<String>,
 }
 
@@ -35,30 +31,23 @@ struct CollectedPlaylist {
 
 /// Sort one playlist (`target = Some(path)`) or every TrackID-referenced
 /// playlist in the XML (`target = None`), then write the result to `output`.
-/// `name_override` is only meaningful with a single target.
+/// Each playlist keeps its NODE, name, and folder position; only the order of
+/// its `<TRACK Key=…/>` children changes.
 pub fn sort_and_write(
     input: &Path,
     output: &Path,
     target: Option<&[String]>,
-    name_override: Option<&str>,
 ) -> Result<Vec<SortedPlaylist>> {
-    let xml_data = std::fs::read(input)
-        .with_context(|| format!("Failed to read {}", input.display()))?;
+    let xml_data =
+        std::fs::read(input).with_context(|| format!("Failed to read {}", input.display()))?;
 
     let (collection, all_playlists) = scan_xml(&xml_data)?;
 
-    let selected = select_targets(all_playlists, target)?;
-
-    let sorted: Vec<SortedPlaylist> = selected
+    let sorted: Vec<SortedPlaylist> = select_targets(all_playlists, target)?
         .into_iter()
-        .map(|p| {
-            let leaf = p.path.last().cloned().unwrap_or_default();
-            let name = match (target, name_override) {
-                (Some(_), Some(custom)) => custom.to_string(),
-                _ => leaf,
-            };
-            let track_ids = sort_tracks(&p.track_ids, &collection);
-            SortedPlaylist { name, track_ids }
+        .map(|p| SortedPlaylist {
+            track_ids: sort_tracks(&p.track_ids, &collection),
+            path: p.path,
         })
         .collect();
 
@@ -111,14 +100,14 @@ fn scan_xml(xml_data: &[u8]) -> Result<(HashMap<String, TrackMeta>, Vec<Collecte
         match reader.read_event() {
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => match e.name().as_ref() {
-                b"COLLECTION" => {
+                "COLLECTION" => {
                     in_collection = true;
-                    if let Some(n) = get_attr(&e, b"Entries")?.and_then(|v| v.parse().ok()) {
+                    if let Some(n) = get_attr(&e, "Entries")?.and_then(|v| v.parse().ok()) {
                         collection.reserve(n);
                     }
                 }
-                b"PLAYLISTS" => in_playlists = true,
-                b"NODE" if in_playlists => {
+                "PLAYLISTS" => in_playlists = true,
+                "NODE" if in_playlists => {
                     let (name, ty, key_type) = playlist_node_attrs(&e)?;
                     path_stack.push(name);
                     if ty == "1" && path_stack.len() > 1 && current.is_none() {
@@ -129,23 +118,23 @@ fn scan_xml(xml_data: &[u8]) -> Result<(HashMap<String, TrackMeta>, Vec<Collecte
                         });
                     }
                 }
-                b"TRACK" if in_collection => {
+                "TRACK" if in_collection => {
                     record_collection_track(&e, &mut collection)?;
                 }
                 _ => {}
             },
             Ok(Event::Empty(e)) => match e.name().as_ref() {
-                b"TRACK" if in_collection => {
+                "TRACK" if in_collection => {
                     record_collection_track(&e, &mut collection)?;
                 }
-                b"TRACK" => {
+                "TRACK" => {
                     if let Some(cur) = current.as_mut() {
-                        if let Some(k) = get_attr(&e, b"Key")? {
+                        if let Some(k) = get_attr(&e, "Key")? {
                             cur.track_ids.push(k);
                         }
                     }
                 }
-                b"NODE" if in_playlists => {
+                "NODE" if in_playlists => {
                     // Self-closing NODE (empty folder or playlist).
                     let (name, ty, key_type) = playlist_node_attrs(&e)?;
                     path_stack.push(name);
@@ -161,9 +150,9 @@ fn scan_xml(xml_data: &[u8]) -> Result<(HashMap<String, TrackMeta>, Vec<Collecte
                 _ => {}
             },
             Ok(Event::End(e)) => match e.name().as_ref() {
-                b"COLLECTION" => in_collection = false,
-                b"PLAYLISTS" => in_playlists = false,
-                b"NODE" if in_playlists => {
+                "COLLECTION" => in_collection = false,
+                "PLAYLISTS" => in_playlists = false,
+                "NODE" if in_playlists => {
                     if let Some(cur) = current.as_ref() {
                         // Matches when we leave the same NODE that started `current`.
                         if path_stack.len() > 1 && path_stack[1..] == cur.path[..] {
@@ -198,9 +187,9 @@ fn record_collection_track(
         #[allow(deprecated)]
         let val = || -> Result<String> { Ok(attr.unescape_value()?.into_owned()) };
         match attr.key.as_ref() {
-            b"TrackID" => id = Some(val()?),
-            b"Tonality" => camelot = parse_camelot(&val()?),
-            b"AverageBpm" => bpm = val()?.parse::<f64>().ok().filter(|v| *v > 0.0),
+            "TrackID" => id = Some(val()?),
+            "Tonality" => camelot = parse_camelot(&val()?),
+            "AverageBpm" => bpm = val()?.parse::<f64>().ok().filter(|v| *v > 0.0),
             _ => {}
         }
     }
@@ -234,85 +223,87 @@ fn sort_tracks(track_ids: &[String], collection: &HashMap<String, TrackMeta>) ->
 
     items.sort_by(|a, b| {
         cmp_some_first(a.1, b.1, |x, y| x.cmp(&y)).then_with(|| {
-            cmp_some_first(a.2, b.2, |x, y| x.partial_cmp(&y).unwrap_or(Ordering::Equal))
+            cmp_some_first(a.2, b.2, |x, y| {
+                x.partial_cmp(&y).unwrap_or(Ordering::Equal)
+            })
         })
     });
 
     items.into_iter().map(|(t, _, _)| t.clone()).collect()
 }
 
+/// Stream-copy the XML, substituting the `<TRACK Key=…/>` refs of each sorted
+/// playlist in place. Everything else (whitespace, attributes, other nodes)
+/// passes through untouched.
 fn rewrite_xml(xml_data: &[u8], playlists: &[SortedPlaylist]) -> Result<Vec<u8>> {
-    // Slice reader + borrowed events: stream-copy without duplicating each event.
+    let mut pending: HashMap<&[String], std::slice::Iter<String>> = playlists
+        .iter()
+        .map(|p| (p.path.as_slice(), p.track_ids.iter()))
+        .collect();
+
     let mut reader = Reader::from_reader(xml_data);
     reader.config_mut().trim_text(false);
 
-    let mut output: Vec<u8> = Vec::with_capacity(xml_data.len() + 4096);
+    let mut output: Vec<u8> = Vec::with_capacity(xml_data.len());
     {
         let mut writer = Writer::new(&mut output);
         let mut in_playlists = false;
-        let mut playlists_depth: i32 = 0;
+        let mut path_stack: Vec<String> = Vec::new();
+        // Depth (path_stack.len()) of the playlist NODE currently being rewritten.
+        let mut active: Option<(usize, std::slice::Iter<String>)> = None;
 
         loop {
             match reader.read_event() {
                 Ok(Event::Eof) => break,
-                Ok(Event::Start(e)) => match e.name().as_ref() {
-                    b"PLAYLISTS" => {
-                        in_playlists = true;
-                        playlists_depth = 0;
-                        writer.write_event(Event::Start(e))?;
-                    }
-                    b"NODE" if in_playlists => {
-                        playlists_depth += 1;
-                        if playlists_depth == 1 {
-                            // ROOT NODE — bump Count by 1 (we insert one folder).
-                            writer.write_event(Event::Start(bump_count_attr(&e, b"Count", 1)?))?;
-                        } else {
-                            writer.write_event(Event::Start(e))?;
+                Ok(Event::Start(e)) => {
+                    match e.name().as_ref() {
+                        "PLAYLISTS" => in_playlists = true,
+                        "NODE" if in_playlists => {
+                            let (name, ty, _) = playlist_node_attrs(&e)?;
+                            path_stack.push(name);
+                            if ty == "1" && active.is_none() && path_stack.len() > 1 {
+                                if let Some(ids) = pending.remove(&path_stack[1..]) {
+                                    active = Some((path_stack.len(), ids));
+                                }
+                            }
                         }
+                        _ => {}
                     }
-                    _ => writer.write_event(Event::Start(e))?,
-                },
-                Ok(Event::End(e)) => match e.name().as_ref() {
-                    b"NODE" if in_playlists => {
-                        if playlists_depth == 1 {
-                            emit_sorted_folder(&mut writer, playlists)?;
-                        }
-                        playlists_depth -= 1;
-                        writer.write_event(Event::End(e))?;
-                    }
-                    b"PLAYLISTS" => {
-                        in_playlists = false;
-                        writer.write_event(Event::End(e))?;
-                    }
-                    _ => writer.write_event(Event::End(e))?,
-                },
-                Ok(other) => {
-                    writer.write_event(other)?;
+                    writer.write_event(Event::Start(e))?;
                 }
+                Ok(Event::Empty(e)) => match e.name().as_ref() {
+                    "TRACK" if active.is_some() => {
+                        let next = active.as_mut().and_then(|(_, ids)| ids.next());
+                        match next {
+                            Some(id) => {
+                                let mut track = BytesStart::new("TRACK");
+                                track.push_attribute(("Key", id.as_str()));
+                                writer.write_event(Event::Empty(track))?;
+                            }
+                            None => writer.write_event(Event::Empty(e))?,
+                        }
+                    }
+                    _ => writer.write_event(Event::Empty(e))?,
+                },
+                Ok(Event::End(e)) => {
+                    match e.name().as_ref() {
+                        "PLAYLISTS" => in_playlists = false,
+                        "NODE" if in_playlists => {
+                            if matches!(active, Some((depth, _)) if depth == path_stack.len()) {
+                                active = None;
+                            }
+                            path_stack.pop();
+                        }
+                        _ => {}
+                    }
+                    writer.write_event(Event::End(e))?;
+                }
+                Ok(other) => writer.write_event(other)?,
                 Err(e) => bail!("XML rewrite error: {}", e),
             }
         }
     }
     Ok(output)
-}
-
-fn emit_sorted_folder<W: std::io::Write>(
-    writer: &mut Writer<W>,
-    playlists: &[SortedPlaylist],
-) -> Result<()> {
-    let count = playlists.len().to_string();
-    let mut folder = BytesStart::new("NODE");
-    folder.push_attribute(("Type", "0"));
-    folder.push_attribute(("Name", SORTED_FOLDER_NAME));
-    folder.push_attribute(("Count", count.as_str()));
-    writer.write_event(Event::Start(folder))?;
-
-    for p in playlists {
-        emit_playlist(writer, &p.name, &p.track_ids)?;
-    }
-
-    writer.write_event(Event::End(BytesEnd::new("NODE")))?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -383,28 +374,34 @@ mod tests {
         assert_eq!(playlists[0].track_ids, vec!["2", "1", "3"]);
     }
 
-    #[test]
-    fn full_roundtrip_inserts_sorted_folder_with_playlist() {
-        let target = vec!["MyList".to_string()];
-        let (col, all) = scan_xml(SAMPLE_XML.as_bytes()).unwrap();
-        let selected = select_targets(all, Some(&target)).unwrap();
-        let sorted: Vec<SortedPlaylist> = selected
+    fn sort_all(xml: &str, target: Option<&[String]>) -> Vec<SortedPlaylist> {
+        let (col, all) = scan_xml(xml.as_bytes()).unwrap();
+        select_targets(all, target)
+            .unwrap()
             .into_iter()
             .map(|p| SortedPlaylist {
-                name: p.path.last().cloned().unwrap(),
                 track_ids: sort_tracks(&p.track_ids, &col),
+                path: p.path,
             })
-            .collect();
+            .collect()
+    }
+
+    #[test]
+    fn full_roundtrip_reorders_tracks_in_place() {
+        let target = vec!["MyList".to_string()];
+        let sorted = sort_all(SAMPLE_XML, Some(&target));
         assert_eq!(sorted[0].track_ids, vec!["1", "2", "3"]);
 
         let out = rewrite_xml(SAMPLE_XML.as_bytes(), &sorted).unwrap();
         let out_str = String::from_utf8(out).unwrap();
-        // New folder wrapping the sorted playlist
-        assert!(out_str.contains(r#"Name="Sorted (Key+BPM)""#));
-        // Sorted playlist keeps the source name (no suffix)
-        assert!(out_str.contains(r#"Name="MyList" Type="1" KeyType="0" Entries="3""#));
-        // ROOT count bumped by 1 (one new folder)
-        assert!(out_str.contains(r#"Count="2""#));
+        // Only the TRACK refs move; whitespace, attributes and ROOT Count are untouched.
+        let expected = SAMPLE_XML.replace(
+            r#"<TRACK Key="2"/>
+        <TRACK Key="1"/>"#,
+            r#"<TRACK Key="1"/>
+        <TRACK Key="2"/>"#,
+        );
+        assert_eq!(out_str, expected);
     }
 
     #[test]
@@ -485,32 +482,45 @@ mod tests {
         let selected = select_targets(all, None).unwrap();
         // KeyType=1 filtered out
         assert_eq!(selected.len(), 2);
-        let names: Vec<&str> = selected.iter().map(|p| p.path.last().unwrap().as_str()).collect();
+        let names: Vec<&str> = selected
+            .iter()
+            .map(|p| p.path.last().unwrap().as_str())
+            .collect();
         assert!(names.contains(&"Top"));
         assert!(names.contains(&"Inner"));
     }
 
     #[test]
-    fn all_mode_emits_folder_with_each_playlist_under_source_name() {
-        let (col, all) = scan_xml(MULTI_PLAYLIST_XML.as_bytes()).unwrap();
-        let selected = select_targets(all, None).unwrap();
-        let sorted: Vec<SortedPlaylist> = selected
-            .into_iter()
-            .map(|p| SortedPlaylist {
-                name: p.path.last().cloned().unwrap(),
-                track_ids: sort_tracks(&p.track_ids, &col),
-            })
-            .collect();
-
+    fn all_mode_rewrites_each_playlist_where_it_lives() {
+        let sorted = sort_all(MULTI_PLAYLIST_XML, None);
         let out = rewrite_xml(MULTI_PLAYLIST_XML.as_bytes(), &sorted).unwrap();
         let out_str = String::from_utf8(out).unwrap();
-        // Sorted folder wraps both playlists (Count=2)
-        assert!(out_str.contains(r#"Type="0" Name="Sorted (Key+BPM)" Count="2""#));
-        // Each playlist inside reuses its source name (no suffix)
-        assert!(out_str.contains(r#"<NODE Name="Top" Type="1" KeyType="0" Entries="2">"#));
-        assert!(out_str.contains(r#"<NODE Name="Inner" Type="1" KeyType="0" Entries="2">"#));
-        // ROOT Count bumped from 2 to 3 (one new folder added)
-        assert!(out_str.contains(r#"Name="ROOT" Count="3""#));
+        let expected = MULTI_PLAYLIST_XML
+            .replace(
+                r#"<TRACK Key="2"/>
+        <TRACK Key="1"/>"#,
+                r#"<TRACK Key="1"/>
+        <TRACK Key="2"/>"#,
+            )
+            .replace(
+                r#"<TRACK Key="3"/>
+          <TRACK Key="4"/>"#,
+                r#"<TRACK Key="4"/>
+          <TRACK Key="3"/>"#,
+            );
+        assert_eq!(out_str, expected);
+        assert!(!out_str.contains("Sorted"));
+    }
+
+    #[test]
+    fn single_target_leaves_other_playlists_alone() {
+        let target = vec!["Folder".to_string(), "Inner".to_string()];
+        let sorted = sort_all(MULTI_PLAYLIST_XML, Some(&target));
+        let out = rewrite_xml(MULTI_PLAYLIST_XML.as_bytes(), &sorted).unwrap();
+        let out_str = String::from_utf8(out).unwrap();
+        // Top keeps its original 2,1 order; Inner becomes 4,3.
+        assert!(out_str.contains("<TRACK Key=\"2\"/>\n        <TRACK Key=\"1\"/>"));
+        assert!(out_str.contains("<TRACK Key=\"4\"/>\n          <TRACK Key=\"3\"/>"));
     }
 
     #[test]
@@ -519,6 +529,9 @@ mod tests {
         let result = select_targets(all, Some(&["Folder".to_string(), "LocBased".to_string()]));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("KeyType"), "expected KeyType error, got: {msg}");
+        assert!(
+            msg.contains("KeyType"),
+            "expected KeyType error, got: {msg}"
+        );
     }
 }

--- a/src/xmlutil.rs
+++ b/src/xmlutil.rs
@@ -5,7 +5,7 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::writer::Writer;
 
 /// Read one attribute's unescaped value from a start tag.
-pub(crate) fn get_attr(e: &BytesStart, name: &[u8]) -> Result<Option<String>> {
+pub(crate) fn get_attr(e: &BytesStart, name: &str) -> Result<Option<String>> {
     for attr in e.attributes() {
         let attr = attr?;
         if attr.key.as_ref() == name {
@@ -26,9 +26,9 @@ pub(crate) fn playlist_node_attrs(e: &BytesStart) -> Result<(String, String, Str
         #[allow(deprecated)]
         let val = || -> Result<String> { Ok(attr.unescape_value()?.into_owned()) };
         match attr.key.as_ref() {
-            b"Name" => name = val()?,
-            b"Type" => ty = val()?,
-            b"KeyType" => key_type = val()?,
+            "Name" => name = val()?,
+            "Type" => ty = val()?,
+            "KeyType" => key_type = val()?,
             _ => {}
         }
     }
@@ -38,25 +38,25 @@ pub(crate) fn playlist_node_attrs(e: &BytesStart) -> Result<(String, String, Str
 /// Rewrite a start tag with one numeric attribute increased by `add`.
 pub(crate) fn bump_count_attr(
     e: &BytesStart,
-    attr_name: &[u8],
+    attr_name: &str,
     add: usize,
 ) -> Result<BytesStart<'static>> {
-    let name = String::from_utf8(e.name().as_ref().to_vec())?;
+    let name = e.name().as_ref().to_string();
     let mut new_start = BytesStart::new(name);
     let mut seen = false;
     for attr in e.attributes() {
         let attr = attr?;
         if attr.key.as_ref() == attr_name {
             seen = true;
-            let val: usize = std::str::from_utf8(&attr.value)?.trim().parse().unwrap_or(0);
+            let val: usize = attr.value.trim().parse().unwrap_or(0);
             let new_val = (val + add).to_string();
-            new_start.push_attribute((std::str::from_utf8(attr_name)?, new_val.as_str()));
+            new_start.push_attribute((attr_name, new_val.as_str()));
         } else {
             new_start.push_attribute(attr.to_owned());
         }
     }
     if !seen {
-        new_start.push_attribute((std::str::from_utf8(attr_name)?, add.to_string().as_str()));
+        new_start.push_attribute((attr_name, add.to_string().as_str()));
     }
     Ok(new_start)
 }


### PR DESCRIPTION
Reworks the `rbsort` workflow, fixes the broken build on `main`, and prepares the 3.1.0 release.

## rbsort sorts in place

Previously every sorted playlist was written into a new `Sorted (Key+BPM)/` folder, so the output XML held both an unsorted original and a sorted copy of each playlist. That copy is redundant: the input is a throwaway Rekordbox export, and the result is loaded as the separate `rekordbox xml` tree, so the real library is never at risk.

Each playlist is now re-sorted inside its own `<NODE>`. Names, folder structure, `Count`/`Entries` and whitespace are preserved byte-for-byte, so the `rekordbox xml` tree becomes a Key+BPM-sorted mirror of `Playlists` and a second run is a no-op.

This also turns the workflow into a sync loop: export to a fixed path, run `rbsort`, point Imported Library at that same file once, then re-export and re-run whenever playlists change.

## Breaking CLI changes

| Before | After |
|---|---|
| `baken rbsort --xml collection.xml` | `baken rbsort collection.xml` |
| `baken cdjsafe --xml collection.xml …` | `baken cdjsafe collection.xml …` |
| output defaults to `<stem>-out.xml` | `rbsort` sorts the input in place; `-o` writes elsewhere (`cdjsafe` unchanged) |
| `--name <NAME>` | removed |

## Build fix

`main` has not compiled since the quick-xml 0.41 to 0.42 bump (#80), which moved element and attribute names from bytes to `&str`. Fixed across `xmlutil.rs`, `rbsort/xml.rs` and `cdjsafe/xml.rs`. No CI job builds on pushes to `main`, so the dependabot merge broke it silently.

## Dependencies

- mp3rgain 3.4.0 to 3.6.0. Verified MP3, AAC/M4A and FLAC gain still land on target, with the MP3 staying byte-identical in size.
- Lockfile moved off the yanked `chacha20` 0.10.1 onto 0.10.2.

## Verification

- `cargo build --release`, `cargo test` (39 passed), `cargo clippy` (no warnings), `cargo package` (68 KB)
- rbsort exercised on a synthetic Rekordbox export: in-place, `-o`, `--playlist`, nested paths, idempotent re-run, and the error paths (missing playlist, `KeyType=1`, removed `--xml`)
- `baken headroom` run end to end on generated MP3, M4A and FLAC files against mp3rgain 3.6

Docs updated: README, `docs/`, and the Cloudflare Worker site (llms.txt, llms-full.txt, FAQ and HowTo JSON-LD, landing page), bumped to 3.1.0. Site deploy happens with the release.