### PR TITLE
Fix bare --backup and --report flags rejecting the missing value

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -81,11 +81,11 @@ pub struct HeadroomArgs {
     pub no_reencode: bool,
 
     /// Create backup before processing (optional DIR; default: <target>/backup)
-    #[arg(long, value_name = "DIR", num_args = 0..=1, default_missing_value = "")]
+    #[arg(long, value_name = "DIR", num_args = 0..=1, default_missing_value = "", value_parser = optional_path)]
     pub backup: Option<PathBuf>,
 
     /// Generate CSV report at PATH (default: <target>/baken_report_<timestamp>.csv)
-    #[arg(long, value_name = "PATH", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_report")]
+    #[arg(long, value_name = "PATH", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_report", value_parser = optional_path)]
     pub report: Option<PathBuf>,
 
     /// Skip CSV report
@@ -99,6 +99,13 @@ pub struct HeadroomArgs {
     /// Skip checking for new versions on startup
     #[arg(long)]
     pub no_update_check: bool,
+}
+
+/// clap's built-in PathBuf parser rejects empty input, which made the bare
+/// `--backup` / `--report` forms fail even though `default_missing_value = ""`
+/// is what marks "flag given, no value". An empty PathBuf means "use the default".
+fn optional_path(s: &str) -> Result<PathBuf, String> {
+    Ok(PathBuf::from(s))
 }
 
 impl HeadroomArgs {


### PR DESCRIPTION
`baken headroom <paths> --backup` and `--report` without a value failed with `error: a value is required for '--backup [<DIR>]' but none was supplied`, even though both flags document the value as optional. Reproduced on the released 3.1.0 Homebrew binary.

## Cause

Both flags use `num_args = 0..=1` with `default_missing_value = ""` and rely on an empty `PathBuf` to mean "use the default location". clap's built-in `PathBuf` value parser rejects empty input (`PathBufValueParser::parse_ref` returns `empty_value`), so the sentinel itself was refused. A scratch reproduction with the same `args.rs` confirmed that only the plain `Option<PathBuf>` field fails and that a permissive parser accepts the empty value.

## Fix

Add a tiny `value_parser = optional_path` function that wraps any string, including the empty one, in a `PathBuf`. `cli.rs` already treats an empty path as "default", so no other code changes.

## Verification

- `cargo test`: 39 passed, `cargo clippy`: clean
- Smoke test with a generated FLAC: `--backup`, `--report`, `--backup --report`, `--backup` before other flags, and `--backup <dir> --report <file>` all behave as documented (default backup folder `<target>/backup`, default report `<target>/baken_report_<timestamp>.csv`)

Note for reviewers: this is based on `main`. `args.rs` moves to `crates/baken/src/args.rs` in #97; git resolves the rename on rebase, whichever lands first.
