### PR TITLE
Make check_ffmpeg fail when ffmpeg exits non-zero

### DIFF
--- a/crates/baken-core/src/error.rs
+++ b/crates/baken-core/src/error.rs
@@ -7,6 +7,9 @@ pub enum Error {
     #[error("ffmpeg not found. Please install ffmpeg first.")]
     FfmpegNotFound,
 
+    #[error("ffmpeg was found but failed to run: {0}")]
+    FfmpegFailed(String),
+
     #[error("operation cancelled")]
     Cancelled,
 

--- a/crates/baken-core/src/tools.rs
+++ b/crates/baken-core/src/tools.rs
@@ -33,11 +33,26 @@ pub(crate) fn ffprobe() -> Command {
     }
 }
 
-/// Verify ffmpeg can be executed.
+/// Verify ffmpeg can be executed and actually runs (issue #99).
+///
+/// A spawn error means the binary is missing; a non-zero exit or unexpected
+/// output means it exists but is broken (bad code signature, missing dylib).
 pub fn check_ffmpeg() -> Result<()> {
-    ffmpeg()
+    let output = ffmpeg()
         .arg("-version")
         .output()
-        .map(|_| ())
-        .map_err(|_| Error::FfmpegNotFound)
+        .map_err(|_| Error::FfmpegNotFound)?;
+    if output.status.success() && output.stdout.starts_with(b"ffmpeg version") {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    let detail = if stderr.is_empty() {
+        format!("ffmpeg -version exited with {}", output.status)
+    } else {
+        let start = stderr.len().saturating_sub(300);
+        let start = stderr.ceil_char_boundary(start);
+        stderr[start..].to_string()
+    };
+    Err(Error::FfmpegFailed(detail))
 }


### PR DESCRIPTION
Fixes #99.

`check_ffmpeg()` mapped any `Command::output()` success to `Ok`, so it only proved that the process spawned. When dyld kills the binary immediately (broken code signature, missing dylib, library validation failure), the exit status is non-zero but the check still passed, and the failure only showed up later as a confusing per-file "No loudnorm data found" error.

The check now requires `status.success()` and stdout starting with `ffmpeg version`. Anything else is returned as a new `Error::FfmpegFailed(String)` variant carrying the trimmed stderr tail (last 300 chars), or the exit status when stderr is empty. A spawn failure still maps to `Error::FfmpegNotFound`.

Verified locally with the real ffmpeg (passes), a fake `ffmpeg` script that prints a dyld message and exits 134 (`Error: ffmpeg was found but failed to run: dyld[123]: ...`), and an empty `PATH` (`ffmpeg not found`). `cargo test`: 39 passed, `cargo fmt --check` and `cargo clippy` clean.

This lets the Mac app drop its own `ffmpeg -version` re-run in `FfmpegTools.swift` once it picks up baken-core 3.2.1.