### PR TITLE
Skip missing files in cdjsafe and suffix the output playlist with -CDJ-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ baken cdjsafe ~/Music/rekordbox/collection.xml \
 ### What it does
 
 1. Reads the target playlist from your exported `collection.xml`.
-2. Converts **every** track to the CDJ-safe profile — **320 kbps CBR MP3 @ 44.1 kHz**, ID3v2.3 tags, artwork kept (JPEG, capped at 500×500):
+2. Converts every track whose file exists to the CDJ-safe profile. Tracks whose files are missing on disk are listed as skipped and left out (the emergency stick still gets everything that is there); only a playlist with no file present at all is an error. Profile: — **320 kbps CBR MP3 @ 44.1 kHz**, ID3v2.3 tags, artwork kept (JPEG, capped at 500×500):
 
    | Source | Action |
    |---|---|
@@ -394,7 +394,7 @@ baken cdjsafe ~/Music/rekordbox/collection.xml \
    | MP3 not exactly 320 kbps CBR @ 44.1 kHz | Re-encode (lossy→lossy, reported) |
    | MP3 already 320 kbps CBR @ 44.1 kHz | **Byte-identical copy** (no generation loss, LAME header untouched) |
 
-3. Emits an updated XML (default: `<input>-out.xml`) where each converted track is a **new entry with a fresh TrackID** that inherits the source's beatgrid (`TEMPO`) and hot/memory cues (`POSITION_MARK`) **verbatim**, grouped in a `CDJ-safe (MP3)/<playlist>` folder. New entries get a `[cdjsafe]` marker appended to their Comments so they're distinguishable after import.
+3. Emits an updated XML (default: `<input>-out.xml`) where each converted track is a **new entry with a fresh TrackID** that inherits the source's beatgrid (`TEMPO`) and hot/memory cues (`POSITION_MARK`) **verbatim**, grouped in a `CDJ-safe (MP3)/<playlist>-CDJ-safe` folder. The `-CDJ-safe` suffix keeps the imported playlist from colliding with the original. New entries get a `[cdjsafe]` marker appended to their Comments so they're distinguishable after import.
 4. Reports every lossy→lossy re-encode so you can refresh those tracks from lossless masters before the next gig.
 
 If any track fails to convert, **no XML is written** — a partial USB defeats the point.
@@ -402,7 +402,7 @@ If any track fails to convert, **no XML is written** — a partial USB defeats t
 ### Importing back into Rekordbox
 
 1. *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select the output XML, restart Rekordbox.
-2. Open the `rekordbox xml` sidebar tree → `CDJ-safe (MP3)/<playlist>`.
+2. Open the `rekordbox xml` sidebar tree → `CDJ-safe (MP3)/<playlist>-CDJ-safe`.
 3. Right-click the imported tracks → **Import to Collection**. Cues and beatgrid come with them — no re-analysis needed.
 4. Export the playlist to USB in EXPORT mode as usual.
 

--- a/crates/baken-core/src/cdjsafe/mod.rs
+++ b/crates/baken-core/src/cdjsafe/mod.rs
@@ -34,6 +34,15 @@ pub enum Action {
     ReencodeLossy,
 }
 
+/// A playlist entry whose file is not on disk. Skipped rather than fatal:
+/// this is the emergency stick, so everything that exists still gets written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedTrack {
+    pub name: String,
+    pub track_id: String,
+    pub location: String,
+}
+
 /// A validated playlist ready to convert. Nothing on disk has been touched yet.
 #[derive(Debug)]
 pub struct Plan {
@@ -41,6 +50,7 @@ pub struct Plan {
     xml_data: Vec<u8>,
     target: Vec<String>,
     sources: Vec<SourceTrack>,
+    skipped: Vec<SkippedTrack>,
     max_track_id: u64,
 }
 
@@ -56,6 +66,19 @@ impl Plan {
     /// Last segment of the playlist path.
     pub fn playlist_name(&self) -> &str {
         self.target.last().map(String::as_str).unwrap_or_default()
+    }
+
+    /// Name of the playlist [`convert`] adds to the XML: the source name with
+    /// `-CDJ-safe` appended, so importing it into rekordbox never collides
+    /// with the original playlist.
+    pub fn output_playlist_name(&self) -> String {
+        format!("{}-CDJ-safe", self.playlist_name())
+    }
+
+    /// Playlist entries whose files were not found on disk; they are left out
+    /// of the conversion and of the new playlist.
+    pub fn skipped(&self) -> &[SkippedTrack] {
+        &self.skipped
     }
 
     /// Track names in playlist order.
@@ -79,7 +102,10 @@ impl Plan {
 pub struct Report {
     pub tracks: Vec<(String, Action)>,
     pub output_xml: PathBuf,
+    /// Name of the playlist written to the XML (`<source>-CDJ-safe`).
     pub playlist_name: String,
+    /// Names of tracks skipped because their files were missing.
+    pub skipped: Vec<String>,
 }
 
 impl Report {
@@ -88,7 +114,9 @@ impl Report {
     }
 }
 
-/// Read `xml`, locate `playlist` (`Folder/Name`), and verify every source file exists.
+/// Read `xml`, locate `playlist` (`Folder/Name`), and check which source files
+/// exist. Missing files are recorded in [`Plan::skipped`] and left out; only a
+/// playlist with no file present at all is an error.
 pub fn plan(xml: &Path, playlist: &str) -> Result<Plan> {
     let target = split_playlist_path(playlist);
     if target.is_empty() {
@@ -101,16 +129,24 @@ pub fn plan(xml: &Path, playlist: &str) -> Result<Plan> {
     if track_ids.is_empty() {
         return Err(Error::EmptyPlaylist(playlist.to_string()));
     }
-    let sources = xml::collect_tracks(&xml_data, &track_ids)?;
+    let all = xml::collect_tracks(&xml_data, &track_ids)?;
 
-    for src in &sources {
-        if !Path::new(&src.location).is_file() {
-            return Err(Error::SourceNotFound {
-                name: src.name.clone(),
-                track_id: src.id.clone(),
-                location: src.location.clone(),
-            });
-        }
+    let (sources, missing): (Vec<_>, Vec<_>) = all
+        .into_iter()
+        .partition(|src| Path::new(&src.location).is_file());
+    let skipped: Vec<SkippedTrack> = missing
+        .into_iter()
+        .map(|src| SkippedTrack {
+            name: src.name,
+            track_id: src.id,
+            location: src.location,
+        })
+        .collect();
+    if sources.is_empty() {
+        return Err(Error::AllSourcesMissing {
+            playlist: playlist.to_string(),
+            count: skipped.len(),
+        });
     }
 
     Ok(Plan {
@@ -118,14 +154,16 @@ pub fn plan(xml: &Path, playlist: &str) -> Result<Plan> {
         xml_data,
         target,
         sources,
+        skipped,
         max_track_id,
     })
 }
 
-/// Transcode every track in `plan` into `out_dir` (created if missing) and
-/// write the updated XML to `output_xml`, or next to the input as
-/// `<stem>-out.xml`. Any conversion failure or cancellation aborts before
-/// the XML is written; a partial USB defeats the purpose.
+/// Transcode every present track in `plan` into `out_dir` (created if
+/// missing) and write the updated XML to `output_xml`, or next to the input as
+/// `<stem>-out.xml`. The new playlist is named `<playlist>-CDJ-safe`. Any
+/// conversion failure or cancellation aborts before the XML is written; a
+/// partial USB defeats the purpose.
 pub fn convert(
     plan: &Plan,
     out_dir: &Path,
@@ -175,7 +213,7 @@ pub fn convert(
 
     let new_tracks = build_new_tracks(&plan.sources, &dest_paths, plan.max_track_id)?;
 
-    let playlist_name = plan.playlist_name().to_string();
+    let playlist_name = plan.output_playlist_name();
     let output = match output_xml {
         Some(p) => p.to_path_buf(),
         None => default_output_path(&plan.xml_path)?,
@@ -194,6 +232,7 @@ pub fn convert(
             .collect(),
         output_xml: output,
         playlist_name,
+        skipped: plan.skipped.iter().map(|s| s.name.clone()).collect(),
     })
 }
 
@@ -299,6 +338,63 @@ mod tests {
 
     fn src(location: &str) -> SourceTrack {
         SourceTrack::test_stub(location)
+    }
+
+    fn write_collection(dir: &Path, locations: &[(&str, &str)]) -> PathBuf {
+        let mut tracks = String::new();
+        let mut keys = String::new();
+        for (i, (name, location)) in locations.iter().enumerate() {
+            tracks.push_str(&format!(
+                r#"<TRACK TrackID="{id}" Name="{name}" TotalTime="100" Location="file://localhost{location}"/>"#,
+                id = i + 1
+            ));
+            keys.push_str(&format!(r#"<TRACK Key="{}"/>"#, i + 1));
+        }
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?><DJ_PLAYLISTS Version="1.0.0"><COLLECTION Entries="{n}">{tracks}</COLLECTION><PLAYLISTS><NODE Type="0" Name="ROOT" Count="1"><NODE Name="Set" Type="1" KeyType="0" Entries="{n}">{keys}</NODE></NODE></PLAYLISTS></DJ_PLAYLISTS>"#,
+            n = locations.len()
+        );
+        let path = dir.join("collection.xml");
+        fs::write(&path, xml).unwrap();
+        path
+    }
+
+    #[test]
+    fn plan_skips_missing_files_and_renames_output_playlist() {
+        let dir = std::env::temp_dir().join(format!("baken-plan-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let present = dir.join("present.wav");
+        fs::write(&present, b"").unwrap();
+        let xml = write_collection(
+            &dir,
+            &[
+                ("Present", present.to_str().unwrap()),
+                ("Gone", dir.join("gone.wav").to_str().unwrap()),
+            ],
+        );
+
+        let plan = plan(&xml, "Set").unwrap();
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan.skipped().len(), 1);
+        assert_eq!(plan.skipped()[0].name, "Gone");
+        assert_eq!(plan.output_playlist_name(), "Set-CDJ-safe");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn plan_fails_when_every_file_is_missing() {
+        let dir = std::env::temp_dir().join(format!("baken-plan-none-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let xml = write_collection(&dir, &[("Gone", dir.join("gone.wav").to_str().unwrap())]);
+
+        let err = plan(&xml, "Set").unwrap_err();
+        assert!(
+            matches!(err, Error::AllSourcesMissing { count: 1, .. }),
+            "{err}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/baken-core/src/error.rs
+++ b/crates/baken-core/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     #[error("Playlist '{0}' has no tracks")]
     EmptyPlaylist(String),
 
+    #[error("None of the {count} tracks in playlist '{playlist}' were found on disk")]
+    AllSourcesMissing { playlist: String, count: usize },
+
     #[error("Source file not found for '{name}' (TrackID {track_id}): {location}")]
     SourceNotFound {
         name: String,

--- a/crates/baken/src/cdjsafe.rs
+++ b/crates/baken/src/cdjsafe.rs
@@ -10,6 +10,14 @@ pub fn run(args: &CdjsafeArgs) -> Result<()> {
     baken_core::check_ffmpeg()?;
 
     let plan = cdjsafe::plan(&args.xml, &args.playlist)?;
+    for skipped in plan.skipped() {
+        println!(
+            "{} '{}' not found on disk — skipped: {}",
+            style("⚠").yellow(),
+            skipped.name,
+            skipped.location
+        );
+    }
     for name in plan.missing_total_time() {
         println!(
             "{} '{}' has no TotalTime attribute — Rekordbox will silently skip its cues on import",
@@ -18,11 +26,16 @@ pub fn run(args: &CdjsafeArgs) -> Result<()> {
         );
     }
 
+    let skipped_note = match plan.skipped().len() {
+        0 => String::new(),
+        n => format!(" ({n} skipped)"),
+    };
     println!(
-        "{} Converting {} tracks from '{}' → {}",
+        "{} Converting {} tracks from '{}'{} → {}",
         style("▸").cyan(),
         style(plan.len()).cyan(),
         style(&args.playlist).bold(),
+        skipped_note,
         args.out_dir.display()
     );
 
@@ -82,6 +95,16 @@ fn print_report(report: &Report) {
             if *action == Action::ReencodeLossy {
                 println!("  {} {}", style("•").dim(), name);
             }
+        }
+    }
+
+    if !report.skipped.is_empty() {
+        println!(
+            "\n{} Skipped (file not found on disk) — not on the stick, not in the new playlist:",
+            style("⚠").yellow()
+        );
+        for name in &report.skipped {
+            println!("  {} {}", style("•").dim(), name);
         }
     }
 


### PR DESCRIPTION
Two changes to \`baken-core::cdjsafe\` driven by real-library testing of the Mac GUI (M-Igashi/baken-mac#10).

**Missing files no longer abort the run.** \`plan()\` used to return \`SourceNotFound\` for the first track whose file was not on disk, which stopped the whole emergency-stick workflow over one stale entry. It now partitions the playlist: present files go into the plan, missing ones are recorded in \`Plan::skipped()\` (name, TrackID, location) and left out of both the conversion and the new playlist. \`Report\` gains a \`skipped\` list. Only a playlist with no file present at all fails, via the new \`Error::AllSourcesMissing\`. The CLI prints each skipped track as a warning before converting and again in the final report.

**The generated playlist is named \`<playlist>-CDJ-safe\`.** Importing the CDJ-safe playlist into rekordbox with the same name as the original made it easy to confuse or overwrite the two. \`Plan::output_playlist_name()\` exposes the name; \`Report::playlist_name\` carries it.

\`SourceNotFound\` is kept for API compatibility but no longer produced by \`plan()\`.

Tests: \`cargo test\` (41 passed, two new tests cover the partitioning and the all-missing error), \`cargo clippy --all-targets\` clean.