### PR TITLE
Leave lossy files alone when the raise is under 1.0 dB instead of proposing a re-encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,13 @@ Each MP3 and AAC/M4A file is categorized into one of three tiers:
    - Raising rounds down to whole steps (never overshoots the ceiling); lowering rounds up (the result never exceeds the ceiling, e.g. TP +0.3 dBTP → -1.5 dB → -1.2 dBTP)
    - Applied automatically (no user confirmation needed)
 
-2. **Re-encode** — the file needs raising by less than 1.5 dB
+2. **Re-encode** — the file needs raising by 1.0 to 1.5 dB (less than one native step, but enough to be worth a lossy pass)
    - Uses ffmpeg for arbitrary precision gain
    - MP3: `libmp3lame` / AAC: `libfdk_aac` (falls back to built-in `aac`)
    - Preserves original bitrate; requires explicit user confirmation
    - Lowering never re-encodes: a lossy pass just to make a file quieter is not worth it, so small overshoots take one full native step instead
 
-3. **Skip** — True Peak already within 0.05 dB of the ceiling, or above it with `--boost-only`
+3. **Skip** — True Peak within 0.05 dB of the ceiling; a lossy file less than 1.0 dB below it (a re-encode for that little is not worth the generation loss, and this is exactly where every file lands after a native step); or above the ceiling with `--boost-only`
 
 ### True Peak Ceiling
 
@@ -279,7 +279,7 @@ The native-lossless raise threshold scales with the chosen ceiling: it is always
 | track04.mp3 | MP3 | 320 | -14.0 | -5.5 | -0.5 | +5.0 | mp3rgain | +4.5 |
 | track06.mp3 | MP3 | 320 | -12.0 | -1.5 | -0.5 | +1.0 | re-encode | +1.0 |
 | track08.m4a | AAC | 256 | -13.0 | -4.0 | -0.5 | +3.5 | native | +3.0 |
-| track10.m4a | AAC | 256 | -12.5 | -1.8 | -0.5 | +0.7 | re-encode | +0.7 |
+| track10.m4a | AAC | 256 | -12.5 | -1.2 | -0.5 | +0.7 | none | 0.0 |
 
 #### Backup Structure
 

--- a/crates/baken-core/src/headroom/analyzer.rs
+++ b/crates/baken-core/src/headroom/analyzer.rs
@@ -31,6 +31,13 @@ pub const GAIN_STEP: f64 = mp3rgain::GAIN_STEP_DB;
 /// Files whose True Peak is within this distance of the target are left alone
 const MIN_EFFECTIVE_GAIN: f64 = 0.05;
 
+/// Smallest raise worth a lossy re-encode. Below one native step the only way
+/// to raise an MP3/AAC file is to re-encode it, and a generation of loss for
+/// less than 1 dB is not a trade anyone wants; after a native step the
+/// leftover is by construction under 1.5 dB, so without this floor every
+/// stepped file came back asking for a re-encode on the next analysis.
+pub const MIN_REENCODE_GAIN: f64 = 1.0;
+
 /// Processing method for the file
 #[derive(Debug, Clone, PartialEq)]
 pub enum GainMethod {
@@ -282,10 +289,14 @@ fn decide_gain(
         // the ceiling. A re-encode just to make a file quieter is never worth it.
         return native(-((-headroom / GAIN_STEP).ceil() as i32));
     }
-    // Raising: whole steps natively, otherwise re-encode for the exact gain.
+    // Raising: whole steps natively. Under one step, re-encode for the exact
+    // gain only when it buys at least MIN_REENCODE_GAIN; otherwise the file is
+    // close enough to the ceiling and is left alone.
     let steps = (headroom / GAIN_STEP).floor() as i32;
     if steps >= 1 {
         native(steps)
+    } else if headroom < MIN_REENCODE_GAIN {
+        (GainMethod::None, 0.0, 0)
     } else if is_aac {
         (GainMethod::AacReencode, headroom, 0)
     } else {
@@ -514,8 +525,8 @@ mod tests {
     fn boost_only_skips_loud_files_and_keeps_raising_logic() {
         assert_eq!(steps(-0.8, GainMode::BoostOnly).0, GainMethod::None);
         assert_eq!(
-            steps(0.7, GainMode::BoostOnly),
-            (GainMethod::Mp3Reencode, 0.7, 0)
+            steps(1.2, GainMode::BoostOnly),
+            (GainMethod::Mp3Reencode, 1.2, 0)
         );
         assert_eq!(
             steps(3.2, GainMode::BoostOnly),
@@ -526,5 +537,23 @@ mod tests {
             (GainMethod::Mp3Lossless, 2.0 * GAIN_STEP, 2)
         );
         assert_eq!(steps(0.02, GainMode::Normalize).0, GainMethod::None);
+    }
+
+    #[test]
+    fn small_raises_of_lossy_files_are_left_alone_instead_of_reencoded() {
+        // The leftover after a native step (always under 1.5 dB) must not turn
+        // into a re-encode proposal on the next analysis.
+        assert_eq!(steps(0.16, GainMode::Normalize), (GainMethod::None, 0.0, 0));
+        assert_eq!(steps(0.99, GainMode::Normalize).0, GainMethod::None);
+        assert_eq!(steps(1.0, GainMode::Normalize).0, GainMethod::Mp3Reencode);
+        assert_eq!(
+            decide_gain(1.2, true, true, GainMode::Normalize),
+            (GainMethod::AacReencode, 1.2, 0)
+        );
+        // Lossless files are still raised exactly, however small the gain.
+        assert_eq!(
+            decide_gain(0.16, false, false, GainMode::Normalize),
+            (GainMethod::FfmpegLossless, 0.16, 0)
+        );
     }
 }

--- a/docs/true-peak-ceiling.md
+++ b/docs/true-peak-ceiling.md
@@ -66,7 +66,7 @@ A -0.5 dBTP delivery target leaves ~0.5 dB of margin against 0 dBTP, which cover
 
 Since v3.3.0 the ceiling is a target, not just a cap: files whose True Peak already exceeds it are lowered to it (lossless files exactly, MP3/AAC in whole 1.5 dB global_gain steps rounded up so the result never sits above the ceiling). This is what makes a loudness-war master and a dynamic master end up at the same True Peak on the USB stick. `--boost-only` restores the raise-only behaviour.
 
-The native-lossless raise threshold (the True Peak below which an MP3/AAC file qualifies for in-place global_gain modification rather than re-encoding) is always `target − 1.5 dB`, since global_gain only works in 1.5 dB steps. Lowering never re-encodes.
+The native-lossless raise threshold (the True Peak below which an MP3/AAC file qualifies for in-place global_gain modification rather than re-encoding) is always `target − 1.5 dB`, since global_gain only works in 1.5 dB steps. Between `target − 1.5 dB` and `target − 1.0 dB` the file can only be raised by re-encoding, which is offered as an opt-in; closer than 1.0 dB to the ceiling (where every file lands after a native step) it is left alone, since v3.3.1. Lowering never re-encodes.
 
 ## Preset crib sheet
 


### PR DESCRIPTION
MP3 and AAC can only be raised natively in 1.5 dB steps, so after one step every file sits somewhere under 1.5 dB below the ceiling. 3.3.0 then proposed a lossy re-encode for that leftover on the next analysis: a track raised by +1.5 dB came back as `Re-encode (MP3, lossy) +0.16 dB` (found while verifying the Mac app, M-Igashi/baken-mac#10). `decide_gain` now returns `None` for lossy raises under the new public `headroom::MIN_REENCODE_GAIN` (1.0 dB). Re-encoding stays available, opt-in as before, for raises between 1.0 and 1.5 dB. Lossless files are unaffected and still raised exactly. Same reasoning as 3.3.0's rule that lowering never re-encodes. Tests cover the floor and the boundary; README and `docs/true-peak-ceiling.md` updated. `cargo test`: 45 passed, clippy clean.