### PR TITLE
Treat Apple Lossless in .m4a as lossless in headroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run `baken --help` or `baken <subcommand> --help` for the full reference.
 
 ### How It Works
 
-1. Scans the target directory for audio files (FLAC, AIFF, WAV, MP3, AAC/M4A)
+1. Scans the target directory for audio files (FLAC, AIFF, WAV, MP3, AAC/M4A, ALAC/M4A)
 2. Measures LUFS (Integrated Loudness) and True Peak using ffmpeg
 3. Computes the gain that puts each file's True Peak at the ceiling (-0.5 dBTP by default). Quiet files get a positive gain, loud files a negative one; `--boost-only` restricts this to positive gains.
 4. Categorizes files by processing method:
@@ -207,6 +207,7 @@ baken selects the optimal method for each file based on format and headroom:
 |--------|--------|-----------|--------------|
 | FLAC, AIFF, WAV | ffmpeg | Arbitrary | None |
 | MP3, AAC/M4A | mp3rgain (built-in) | 1.5dB steps | **None** (global_gain modification) |
+| ALAC/M4A | ffmpeg (re-encoded as ALAC) | Arbitrary | **None** (lossless codec) |
 | MP3, AAC/M4A | ffmpeg re-encode | Arbitrary | Inaudible at ≥256kbps |
 
 Lossless files are written back in their **original sample format** — a 16-bit AIFF stays 16-bit, a 32-bit float WAV stays 32-bit float — so file size does not grow and float masters are not truncated. FLAC is the one partial exception: ffmpeg's FLAC encoder only accepts 16- and 24-bit output, so an 8-bit FLAC becomes 16-bit and a 20-bit FLAC becomes 24-bit.

--- a/crates/baken-core/src/headroom/analyzer.rs
+++ b/crates/baken-core/src/headroom/analyzer.rs
@@ -137,6 +137,19 @@ struct FfprobeOutput {
 /// Parse the overall bitrate from ffmpeg's input dump on stderr, e.g.
 /// `  Duration: 00:03:50.32, start: 0.025057, bitrate: 320 kb/s`.
 /// Returns None for "N/A" or unexpected formatting; callers fall back to ffprobe.
+/// Codec of the first audio stream from ffmpeg's input dump
+/// ("Stream #0:0 ... Audio: alac (alac / 0x63616C61), 44100 Hz ...").
+fn parse_stderr_codec(stderr: &str) -> Option<String> {
+    stderr
+        .lines()
+        .find(|line| line.contains("Audio:"))?
+        .split("Audio:")
+        .nth(1)?
+        .split_whitespace()
+        .next()
+        .map(|codec| codec.trim_end_matches(',').to_ascii_lowercase())
+}
+
 fn parse_stderr_bitrate(stderr: &str) -> Option<u32> {
     stderr
         .lines()
@@ -348,7 +361,10 @@ pub fn analyze_file_with_target(
     }
 
     let is_mp3 = scanner::is_mp3(path);
-    let is_aac = scanner::is_aac(path);
+    // An .m4a can hold Apple Lossless as well as AAC. ALAC is lossless: it
+    // gets the exact ffmpeg gain like FLAC instead of native AAC steps, which
+    // mp3rgain rejects ("No AAC audio track found").
+    let is_aac = scanner::is_aac(path) && parse_stderr_codec(&stderr).as_deref() != Some("alac");
     let is_lossy = is_mp3 || is_aac;
 
     // The loudnorm run's stderr already contains the bitrate in the input
@@ -487,6 +503,15 @@ mod tests {
         let loudnorm = result.unwrap();
         assert_eq!(loudnorm.input_i, "-10.00");
         assert_eq!(loudnorm.input_tp, "0.50");
+    }
+
+    #[test]
+    fn codec_is_read_from_the_input_dump() {
+        let alac = "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'x.m4a':\n  Duration: 00:05:01.00, start: 0.000000, bitrate: 1030 kb/s\n  Stream #0:0[0x1](und): Audio: alac (alac / 0x63616C61), 44100 Hz, stereo, s16p, 1029 kb/s (default)\n";
+        assert_eq!(parse_stderr_codec(alac).as_deref(), Some("alac"));
+        let aac = "  Stream #0:0[0x1](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 256 kb/s (default)\n";
+        assert_eq!(parse_stderr_codec(aac).as_deref(), Some("aac"));
+        assert_eq!(parse_stderr_codec("no streams here"), None);
     }
 
     fn steps(headroom: f64, mode: GainMode) -> (GainMethod, f64, i32) {

--- a/crates/baken-core/src/headroom/processor.rs
+++ b/crates/baken-core/src/headroom/processor.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -166,6 +166,20 @@ fn output_args(extension: &str, source: Option<&SourceFormat>) -> Vec<String> {
             "-write_id3v2".into(),
             "1".into(),
         ],
+        // Apple Lossless in an MP4 container. ffmpeg's alac encoder takes
+        // s16p or s32p; s32p is written as 24-bit.
+        "m4a" | "mp4" => {
+            let sample_fmt = match source.and_then(|s| s.bits) {
+                Some(bits) if bits <= 16 => "s16p",
+                _ => "s32p",
+            };
+            vec![
+                "-c:a".into(),
+                "alac".into(),
+                "-sample_fmt".into(),
+                sample_fmt.into(),
+            ]
+        }
         // -write_bext preserves Broadcast Wave Format chunks (time_reference, umid).
         "wav" => vec![
             "-c:a".into(),
@@ -187,6 +201,17 @@ fn apply_gain_ffmpeg(file_path: &Path, gain_db: f64) -> Result<()> {
 
     let volume_arg = format!("volume={}dB", gain_db);
     let source = probe_source_format(file_path);
+    // The lossless path only handles .m4a/.mp4 when the payload is ALAC;
+    // anything else in that container would be silently re-encoded as AAC.
+    if matches!(extension.to_ascii_lowercase().as_str(), "m4a" | "mp4")
+        && source.as_ref().map(|s| s.codec.as_str()) != Some("alac")
+    {
+        bail!(
+            "{} is not Apple Lossless (codec {}); lossless gain applies to ALAC only",
+            file_path.display(),
+            source.map(|s| s.codec).unwrap_or_else(|| "unknown".into())
+        );
+    }
 
     let mut cmd = crate::tools::ffmpeg();
     cmd.args(["-y", "-i"])
@@ -401,6 +426,16 @@ mod tests {
     /// A codec the container's muxer can't write, and an unreadable probe, both
     /// fall back to the pre-#74 24-bit output rather than failing the run.
     #[test]
+    fn alac_keeps_its_container_and_bit_depth() {
+        let m4a16 = output_args("m4a", Some(&source("alac", Some(16))));
+        assert_eq!(codec_of(&m4a16), "alac");
+        assert!(m4a16.contains(&"s16p".to_string()));
+        let m4a24 = output_args("m4a", Some(&source("alac", Some(24))));
+        assert!(m4a24.contains(&"s32p".to_string()));
+        assert_eq!(codec_of(&output_args("mp4", None)), "alac");
+    }
+
+    #[test]
     fn falls_back_when_codec_not_writable() {
         // Byte order is container-specific: LE flavours can't go into AIFF.
         assert_eq!(
@@ -423,7 +458,7 @@ mod tests {
         assert_eq!(value_of(&aiff, "-write_id3v2").as_deref(), Some("1"));
         let wav = output_args("wav", Some(&source("pcm_s16le", Some(16))));
         assert_eq!(value_of(&wav, "-write_bext").as_deref(), Some("1"));
-        assert!(output_args("m4a", None).is_empty());
+        assert!(output_args("ogg", None).is_empty());
     }
 
     /// ffprobe reports bits_per_sample as a number, bits_per_raw_sample as a


### PR DESCRIPTION
An `.m4a` can hold ALAC as well as AAC. headroom classified every `.m4a` as AAC by extension, so an Apple Lossless file was sent down the native AAC gain path and mp3rgain failed with `No AAC audio track found` (seen on a real library in M-Igashi/baken-mac#10). The analyzer now reads the codec from the loudnorm run's input dump (no extra ffprobe) and treats `alac` as lossless: exact gain via ffmpeg, written back as ALAC at the source bit depth (`s16p` for 16-bit, `s32p`/24-bit otherwise). `apply_gain_ffmpeg` refuses an `.m4a`/`.mp4` whose payload is not ALAC so nothing is ever silently re-encoded to AAC. Requires an ffmpeg with the `alac` encoder (present in stock builds; added to the Mac app's LGPL build). Tests: codec parsing, ALAC output args, 47 passed; clippy clean.